### PR TITLE
secure_element

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -363,7 +363,10 @@ PRODUCT_PACKAGES += \
 
 PRODUCT_PACKAGES += \
     nfc_nci.nqx.default.hw \
-    vendor.nxp.hardware.nfc@2.0-service
+    vendor.nxp.hardware.nfc@2.0-service \
+    android.hardware.secure_element@1.0.vendor \
+    android.hardware.secure_element@1.1.vendor \
+    android.hardware.secure_element@1.2.vendor
 
 PRODUCT_PACKAGES += \
     jcos_nq_client \


### PR DESCRIPTION
"FAILED: ninja: 'vendor/xiaomi/sm8350-common/proprietary/vendor/lib64/android.hardware.secure_element@1.0.so', needed by 'out/target/product/renoir/vendor/lib64/android.hardware.secure_element@1.0.so', missing and no known rule make it"
will be fixed.